### PR TITLE
Fixed race conditions in Child and Pool classes

### DIFF
--- a/src/Arara/Process/Child.php
+++ b/src/Arara/Process/Child.php
@@ -211,14 +211,15 @@ class Child implements Process
      */
     public function wait()
     {
-        if(!is_null($this->status)) {
+        if (!is_null($this->status)) {
             return false;
         }
 
         $waitStatus = 0;
         $waitReturn = $this->control->waitProcessId($this->getId(), $waitStatus);
-        if($waitReturn === $this->getId())
+        if ($waitReturn === $this->getId()) {
             $this->isRunning = false ;
+        }
 
         $this->status = new Status($waitStatus);
 

--- a/src/Arara/Process/Child.php
+++ b/src/Arara/Process/Child.php
@@ -217,6 +217,8 @@ class Child implements Process
 
         $waitStatus = 0;
         $waitReturn = $this->control->waitProcessId($this->getId(), $waitStatus);
+        if($waitReturn === $this->getId())
+            $this->isRunning = false ;
 
         $this->status = new Status($waitStatus);
 

--- a/src/Arara/Process/Child.php
+++ b/src/Arara/Process/Child.php
@@ -211,7 +211,7 @@ class Child implements Process
      */
     public function wait()
     {
-        if (! $this->isRunning()) {
+        if(!is_null($this->status)) {
             return false;
         }
 

--- a/src/Arara/Process/Pool.php
+++ b/src/Arara/Process/Pool.php
@@ -150,9 +150,6 @@ class Pool implements Process, Countable
     {
         $result = $this->isRunning();
         foreach ($this->process as $process) {
-            if (! $process->isRunning()) {
-                continue;
-            }
             $result = $process->wait() && $result;
         }
 

--- a/tests/unit/Arara/Process/ChildTest.php
+++ b/tests/unit/Arara/Process/ChildTest.php
@@ -317,24 +317,11 @@ class ChildTest extends TestCase
         $this->assertFalse($child->isRunning());
     }
 
-    public function testShouldWaitProcessIfProcessIsRunning()
+    public function testShouldWaitProcessIfWaitStatusNotReaped()
     {
         $processId = 123456;
 
-        $controlSignalMock = $this->controlSignal
-            ->setMethods(array('send'))
-            ->getMock();
-        $controlSignalMock
-            ->expects($this->once())
-            ->method('send')
-            ->with(0, $processId)
-            ->will($this->returnValue(true));
-
         $controlMock = $this->control->getMock();
-        $controlMock
-            ->expects($this->once())
-            ->method('signal')
-            ->will($this->returnValue($controlSignalMock));
         $controlMock
             ->expects($this->once())
             ->method('waitProcessId')
@@ -347,14 +334,23 @@ class ChildTest extends TestCase
 
         $this->assertTrue($child->wait());
     }
-    public function testShouldNotWaitWhenProcessIsNotRunning()
+    
+    public function testShouldNotWaitWhenProcessAlreadyReaped()
     {
+        $processId = 123456;
+
         $controlMock = $this->control->getMock();
         $controlMock
-            ->expects($this->never())
-            ->method('waitProcessId');
+            ->expects($this->once())
+            ->method('waitProcessId')
+            ->will($this->returnValue($processId));
 
         $child = new Child($this->action->getMock(), $controlMock);
+        $context = $this->getObjectPropertyValue($child, 'context');
+        $context->processId = $processId;
+        $context->isRunning = true;
+
+        $this->assertTrue($child->wait()) ;
 
         $this->assertFalse($child->wait());
     }
@@ -373,20 +369,7 @@ class ChildTest extends TestCase
     {
         $processId = 123456;
 
-        $controlSignalMock = $this->controlSignal
-            ->setMethods(array('send'))
-            ->getMock();
-        $controlSignalMock
-            ->expects($this->once())
-            ->method('send')
-            ->with(0, $processId)
-            ->will($this->returnValue(true));
-
         $controlMock = $this->control->getMock();
-        $controlMock
-            ->expects($this->once())
-            ->method('signal')
-            ->will($this->returnValue($controlSignalMock));
         $controlMock
             ->expects($this->once())
             ->method('waitProcessId')
@@ -408,20 +391,7 @@ class ChildTest extends TestCase
     {
         $processId = 123456;
 
-        $controlSignalMock = $this->controlSignal
-            ->setMethods(array('send'))
-            ->getMock();
-        $controlSignalMock
-            ->expects($this->once())
-            ->method('send')
-            ->with(0, $processId)
-            ->will($this->returnValue(true));
-
         $controlMock = $this->control->getMock();
-        $controlMock
-            ->expects($this->once())
-            ->method('signal')
-            ->will($this->returnValue($controlSignalMock));
         $controlMock
             ->expects($this->once())
             ->method('waitProcessId')

--- a/tests/unit/Arara/Process/PoolTest.php
+++ b/tests/unit/Arara/Process/PoolTest.php
@@ -415,29 +415,26 @@ class PoolTest extends TestCase
         $pool->wait();
     }
 
-    public function testShouldNotWaitNonRunningProcessAtThePoolWhenTryingToWaitPool()
+    public function testShouldNotWaitReapedProcessAtThePoolWhenTryingToWaitPool()
     {
         $process1 = $this->getMock('Arara\Process\Process');
         $process1
             ->expects($this->any())
-            ->method('isRunning')
+            ->method('wait')
             ->will($this->onConsecutiveCalls(true, false));
-        $process1
-            ->expects($this->never())
-            ->method('wait');
-
+ 
         $process2 = $this->getMock('Arara\Process\Process');
         $process2
-            ->expects($this->any())
-            ->method('isRunning')
-            ->will($this->returnValue(true));
-        $process2
             ->expects($this->once())
-            ->method('wait');
+            ->method('wait')
+            ->will($this->returnValue(true)) ;
 
         $pool = new Pool(2, true);
         $pool->attach($process1);
         $pool->attach($process2);
+        
+        $process1->wait() ;
+        
         $pool->wait();
     }
 }


### PR DESCRIPTION
Hi Henrique,

I am using your Process library in a small project I am working on, and I found a race condition that sometimes causes a child process to exit with error status, when in fact it didn't. Thought I'd contribute back my fix.  Hope it proves useful.

I'm very new to github and to pull requests, so hopefully I have done this correctly.  Let me know if something isn't right.

Details follow.

Regards,
Damien.

The Child class' wait method checks the isRunning method to determine whether the child has terminated or not.  However, a race condition exists where the process has terminated before the wait method is called.  In this case, isRunning returns false, and then the wait method will return false, rather than calling waitpid to reap the process and get the status.  Instead of checking isRunning, the method now checks to see if the status has been set in the instance already.  If not, then the wait method hasn't been previously called for this child and so it calls the waitpid function.

In Pool class, it checks if the child process is running by again calling its isRunning method.  If the child process terminates before the wait method of Pool is called, then again the Child object's wait method is never called.  The test for whether isRunning is false for the Child object is omitted, so that it must call the wait method of the Child object.  If the child has already had its wait method called, then it will just return false as intended.